### PR TITLE
travis: Test with minimal required rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: rust
 before_script:
   - echo "yes" | sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu trusty main universe restricted multiverse"
   - sudo apt-get update -qq
-  - sudo apt-get -qq install libsdl2-dev 
+  - sudo apt-get -qq install libsdl2-dev
 rust:
-    - stable
+  - 1.8.0

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ In that form, they cannot attack anymore, but have a defense bonus.
 
 ## Prequisites
 
-* SDL 2 (`libsdl2-dev` on Ubuntu)
-* FreeType (`libfreetype6-dev` on Ubuntu)
+ * SDL 2 (`libsdl2-dev` on Ubuntu)
+ * FreeType (`libfreetype6-dev` on Ubuntu)
+ * Rust version 1.8.0 or higher
 
 ## Building
 


### PR DESCRIPTION
We should document the minimal required rust version and test if it still builds in travis.
