### PR TITLE
Fix panic when passing the reconnect flag

### DIFF
--- a/src/bin/cli_client.rs
+++ b/src/bin/cli_client.rs
@@ -6,7 +6,7 @@ extern crate docopt;
 use std::net::TcpStream;
 use std::ops::Deref;
 
-use rpsrtsrs::state::{Game, ClientId};
+use rpsrtsrs::state::{Game};
 use rpsrtsrs::network::{Message};
 
 use docopt::Docopt;
@@ -28,7 +28,7 @@ Options:
 struct Args {
     flag_p: u16,
     flag_i: String,
-    flag_r: Option<ClientId>,
+    flag_r: Option<u32>,
 }
 
 fn main() {
@@ -44,7 +44,7 @@ fn main() {
 
     match reconnect {
         Some(id) => {
-            encode_into(&Message::ClientReconnect(id), &mut stream, SizeLimit::Infinite).unwrap();
+            encode_into(&Message::ClientReconnect(id.into()), &mut stream, SizeLimit::Infinite).unwrap();
         },
         None => {
             encode_into(&Message::ClientHello, &mut stream, SizeLimit::Infinite).unwrap();


### PR DESCRIPTION
docopt wasn't able to decode directly to the ClientId type. So we decode
into an u32 and convert it before passing it to the Message constructor.

```
     Running `target/debug/cli_client -r 0`
thread '<main>' panicked at 'Unrecognized struct field: '_field0'', /home/roughl/.multirust/toolchains/stable/cargo/registry/src/github.com-88ac128001ac3a9a/docopt-0.6.80/src/dopt.rs:481
```
