### PR TITLE
Add contribution guidelines with 7 commit message rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to rpsrtsrs
+
+#### Table Of Contents
+
+[Styleguides](#styleguides)
+  * [Git Commit Messages](#git-commit-messages)
+
+## Styleguides
+
+### Git Commit Messages
+
+Please follow [the seven rules](https://chris.beams.io/posts/git-commit/#seven-rules) of [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/):
+
+ 1. [Separate subject from body with a blank line](https://chris.beams.io/posts/git-commit/#separate)
+ 2. [Limit the subject line to 50 characters](https://chris.beams.io/posts/git-commit/#limit-50)
+ 3. [Capitalize the subject line](https://chris.beams.io/posts/git-commit/#capitalize)
+ 4. [Do not end the subject line with a period](https://chris.beams.io/posts/git-commit/#end)
+ 5. [Use the imperative mood in the subject line](https://chris.beams.io/posts/git-commit/#imperative)
+ 6. [Wrap the body at 72 characters](https://chris.beams.io/posts/git-commit/#wrap-72)
+ 7. [Use the body to explain what and why vs. how](https://chris.beams.io/posts/git-commit/#why-not-how)


### PR DESCRIPTION
https://github.com/coredump-ch/rpsrtsrs/pull/59#issuecomment-321495246:

> > One minor nitpick: Could you start the commit messages with an uppercase letter? I try to follow the recommendations from https://chris.beams.io/posts/git-commit/. I could also change it for you if you don't mind :wink:
> 
> Looking through the commit history I noticed that I didn't always follow the recommendations myself :scream:
> 

Well, maybe we need to set up a little reminder for ourselves if we want to stick to these rules.

The linked blogpost recommends to write the rules down, too:

> In order to create a useful revision history, teams should first agree on a commit message convention that defines at least the following three things:
> [...]
> [...] **Spell these things out**, remove the guesswork, and make it all as simple as possible.

(emphasis mine)

The right place for this seems to be `CONTRIBUTING.md`: A link to this file [will be displayed by GitHub whenever someone opens a pull request or creates an issue](https://help.github.com/articles/setting-guidelines-for-repository-contributors/).