### PR TITLE
Convert all vector types to cgmath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "rpsrtsrs"
 version = "0.1.0"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cgmath 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-texture 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -32,6 +33,11 @@ dependencies = [
 [[package]]
 name = "android_glue"
 version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "approx"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -90,6 +96,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gleam 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cgmath"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -869,6 +886,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"
@@ -1145,6 +1165,7 @@ dependencies = [
 "checksum adler32 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ff33fe13a08dbce05bcefa2c68eea4844941437e33d6f808240b54d7157b9cd"
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
+"checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 "checksum arrayvec 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "699e63a93b79d717e8c3b5eb1b28b7780d0d6d9e59a72eb769291c83b0c8dc67"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
@@ -1154,6 +1175,7 @@ dependencies = [
 "checksum byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96c8b41881888cc08af32d47ac4edd52bc7fa27fef774be47a92443756451304"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum cgl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "86765cb42c2a2c497e142af72517c1b4d7ae5bb2f25dfa77a5c69642f2342d89"
+"checksum cgmath 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2372c02a7cfabf871ec42ecc968406a7b5916bcfd51defc6a0498fcb19fa2e5"
 "checksum cmake 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ebbb35d3dc9cd09497168f33de1acb79b265d350ab0ac34133b98f8509af1f"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum cocoa 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4047fed6536f40cc2ae5e7834fb38e382c788270191c4cd69196f89686d076ce"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgmath 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-texture 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston2d-graphics 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde_derive = "1.0"
 serde = "1.0"
 docopt = "0.8"
 cgmath = { version = "0.15", features = ["serde"] }
+num = "0.1"
 
 [dependencies.pistoncore-sdl2_window]
 version = "0.43"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ bincode = "0.8"
 serde_derive = "1.0"
 serde = "1.0"
 docopt = "0.8"
+cgmath = { version = "0.15", features = ["serde"] }
 
 [dependencies.pistoncore-sdl2_window]
 version = "0.43"

--- a/src/bin/cli_client.rs
+++ b/src/bin/cli_client.rs
@@ -9,6 +9,7 @@ use std::ops::Deref;
 use std::io::Write;
 use std::{thread, time};
 
+use rpsrtsrs::common::Vec2;
 use rpsrtsrs::state::GameState;
 use rpsrtsrs::network::{Command, Message};
 
@@ -82,7 +83,7 @@ fn main() {
         let x = args.arg_x.expect("<x> missing");
         let y = args.arg_y.expect("<y> missing");
         serialize_into(&mut stream,
-                       &Message::Command(Command::Move(id.into(), [x, y])),
+                       &Message::Command(Command::Move(id.into(), Vec2::new(x, y))),
                        Infinite)
             .unwrap();
         stream.flush().unwrap();

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -54,11 +54,11 @@ fn main() {
         }
 
         if let Some(args) = e.mouse_cursor_args() {
-            app.on_mouse_move(args);
+            app.on_mouse_move(args.into());
         }
 
         if let Some(args) = e.mouse_scroll_args() {
-            app.on_mouse_scroll(args);
+            app.on_mouse_scroll(args.into());
         }
 
         if let Some(u) = e.update_args() {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,27 +1,26 @@
+use std::thread;
+use std::time;
+use std::mem;
 use std::sync::{Mutex, Arc};
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::{SocketAddr, ToSocketAddrs, TcpStream};
 use std::collections::VecDeque;
 use std::error::Error;
-use std::mem;
+
 use opengl_graphics::GlGraphics;
 use opengl_graphics::glyph_cache::GlyphCache;
 use piston::input::{Button, Key, MouseButton, RenderArgs, UpdateArgs};
-
-use std::{thread, time};
-use std::net::TcpStream;
-use network::{Command, Message};
-
 use bincode::{serialize_into, deserialize_from, Infinite};
 
+use network::{Command, Message};
 use state::{UnitId, ClientId, WorldState, GameState, UNIT_SIZE};
 use shapes::Shape;
-use colors;
-use colors::{BLACK, ORANGE, WHITE};
+use colors::{self, BLACK, ORANGE, WHITE};
 
 pub mod menu;
 pub mod error;
 
 use self::menu::Menu;
+
 
 pub struct NetworkClient {
     pub game_state: Arc<Mutex<Option<GameState>>>,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,5 @@
+//! Common types and functionality used both in server and client.
+use cgmath::Vector2;
+
+/// Cartesian x/y coordinates using f64.
+pub type Vec2 = Vector2<f64>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,12 @@ extern crate piston;
 extern crate graphics;
 extern crate opengl_graphics;
 extern crate rand;
+extern crate cgmath;
 #[cfg(feature = "include_sdl2")] extern crate sdl2_window;
 #[cfg(feature = "include_glfw")] extern crate glfw_window;
 #[cfg(feature = "include_glutin")] extern crate glutin_window;
 
+pub mod common;
 pub mod shapes;
 pub mod state;
 pub mod network;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate graphics;
 extern crate opengl_graphics;
 extern crate rand;
 extern crate cgmath;
+extern crate num;
 #[cfg(feature = "include_sdl2")] extern crate sdl2_window;
 #[cfg(feature = "include_glfw")] extern crate glfw_window;
 #[cfg(feature = "include_glutin")] extern crate glutin_window;

--- a/src/network.rs
+++ b/src/network.rs
@@ -3,6 +3,7 @@
 //! Everything related to the network protocol between the sever and the
 //! clients.
 
+use common::Vec2;
 use state::{GameState, WorldState, UnitId, ClientId};
 
 /// Commands alter the game state.
@@ -12,7 +13,7 @@ use state::{GameState, WorldState, UnitId, ClientId};
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub enum Command {
     /// Move command with unit ID and target
-    Move(UnitId, [f64; 2]),
+    Move(UnitId, Vec2),
     /// Let the unit shoot
     Shoot(UnitId),
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,6 +14,7 @@ use bincode::{serialize, deserialize_from, Infinite, Bounded};
 use common::Vec2;
 use state::{WorldState, GameState, Player, Unit, UnitId};
 use network::{Message, Command};
+use num::clamp;
 
 /// A `Server` instance holds global server state.
 pub struct Server {
@@ -228,23 +229,9 @@ pub fn handle_command(world: &WorldState,
                 for unit in player.units.iter_mut() {
                     if unit.id == id {
                         println!("Found it :)");
-                        // TODO: This can probably be cleaned up with cgmath
-                        // vector operations.
                         let mut target = [0.0; 2];
-                        target[0] = if move_target[0] > world.x {
-                            world.x
-                        } else if move_target[0] < 0.0 {
-                            0.0
-                        } else {
-                            move_target[0]
-                        };
-                        target[1] = if move_target[1] > world.y {
-                            world.y
-                        } else if move_target[1] < 0.0 {
-                            0.0
-                        } else {
-                            move_target[1]
-                        };
+                        target[0] = clamp(move_target[0], 0.0, world.x);
+                        target[1] = clamp(move_target[1], 0.0, world.y);
                         let dx = target[0] - unit.position[0];
                         let dy = target[1] - unit.position[1];
                         if dx.is_sign_negative() {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -229,11 +229,11 @@ pub fn handle_command(world: &WorldState,
                 for unit in player.units.iter_mut() {
                     if unit.id == id {
                         println!("Found it :)");
-                        let mut target = [0.0; 2];
-                        target[0] = clamp(move_target[0], 0.0, world.x);
-                        target[1] = clamp(move_target[1], 0.0, world.y);
-                        let dx = target[0] - unit.position[0];
-                        let dy = target[1] - unit.position[1];
+                        let mut target = Vec2::new(0.0, 0.0);
+                        target.x = clamp(move_target.x, 0.0, world.x);
+                        target.y = clamp(move_target.y, 0.0, world.y);
+                        let dx = target.x - unit.position.x;
+                        let dy = target.y - unit.position.y;
                         if dx.is_sign_negative() {
                             unit.angle = (dy / dx).atan() + PI;
                         } else {

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -4,11 +4,13 @@ use self::graphics::types::Triangle;
 use self::graphics::math;
 use super::state;
 
+use common::Vec2;
+
 
 pub trait Shape {
     fn get_shape(&self, size: f64) -> Triangle;
 
-    fn is_hit(&self, size: f64, position: [f64;2]) -> bool;
+    fn is_hit(&self, size: f64, position: Vec2) -> bool;
 }
 
 impl Shape for state::Unit {
@@ -31,24 +33,24 @@ impl Shape for state::Unit {
             *point = math::transform_vec(rotation_matrix, *point);
 
             // Translate to effective position
-            *point = math::add(*point, self.position);
+            *point = math::add(*point, self.position.into());
         }
 
         triangle
     }
 
     /// Calculate whether or not this unit is hit by the point at the specified position.
-    fn is_hit(&self, size: f64, position: [f64;2]) -> bool {
+    fn is_hit(&self, size: f64, position: Vec2) -> bool {
         let hitbox = self.get_shape(size);
-        math::inside_triangle(hitbox, position)
+        math::inside_triangle(hitbox, position.into())
     }
 }
 
 #[cfg(test)]
 mod test {
     use std::f64::consts::FRAC_PI_2;
-    use super::Shape;
-    use super::state;
+
+    use super::{Shape, Vec2, state};
 
     #[test]
     fn test_hitbox() {
@@ -57,12 +59,12 @@ mod test {
         //    /\
         //   /__\
         //
-        let mut unit = state::Unit::new(0, [100.0, 100.0]);
+        let mut unit = state::Unit::new(0, Vec2::new(100.0, 100.0));
         unit.angle = FRAC_PI_2;
 
         // The following points should be outside of the hitbox.
-        assert_eq!(unit.is_hit(50.0, [0.0, 0.0]), false);
-        assert_eq!(unit.is_hit(50.0, [50.0, 50.0]), false);
+        assert_eq!(unit.is_hit(50.0, Vec2::new(0.0, 0.0)), false);
+        assert_eq!(unit.is_hit(50.0, Vec2::new(50.0, 50.0)), false);
 
         // The following five points should be inside the hitbox.
         //      .
@@ -70,18 +72,18 @@ mod test {
         //   ./_._\.
         //
         let vertical_distance = 50.0 / 2.0 - 1.0;
-        assert_eq!(unit.is_hit(50.0, [100.0, 100.0]), true);
-        assert_eq!(unit.is_hit(50.0, [100.0, 100.0 - vertical_distance]), true);
-        assert_eq!(unit.is_hit(50.0, [100.0, 100.0 + vertical_distance]), true);
-        assert_eq!(unit.is_hit(50.0, [100.0 - vertical_distance, 100.0 + vertical_distance]), true);
-        assert_eq!(unit.is_hit(50.0, [100.0 + vertical_distance, 100.0 + vertical_distance]), true);
+        assert_eq!(unit.is_hit(50.0, Vec2::new(100.0, 100.0)), true);
+        assert_eq!(unit.is_hit(50.0, Vec2::new(100.0, 100.0 - vertical_distance)), true);
+        assert_eq!(unit.is_hit(50.0, Vec2::new(100.0, 100.0 + vertical_distance)), true);
+        assert_eq!(unit.is_hit(50.0, Vec2::new(100.0 - vertical_distance, 100.0 + vertical_distance)), true);
+        assert_eq!(unit.is_hit(50.0, Vec2::new(100.0 + vertical_distance, 100.0 + vertical_distance)), true);
 
         // The following two points should be outside the hitbox.
         //
         //  . /\ .
         //   /__\
         //
-        assert_eq!(unit.is_hit(50.0, [100.0 - vertical_distance, 100.0]), false);
-        assert_eq!(unit.is_hit(50.0, [100.0 + vertical_distance, 100.0]), false);
+        assert_eq!(unit.is_hit(50.0, Vec2::new(100.0 - vertical_distance, 100.0)), false);
+        assert_eq!(unit.is_hit(50.0, Vec2::new(100.0 + vertical_distance, 100.0)), false);
     }
 }

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -26,7 +26,7 @@ impl Shape for state::Unit {
         // Transformations
         for point in triangle.iter_mut() {
             // Translate center to zero point
-            *point = math::add(*point, [-size / 2.0, -size / 2.0]);
+            *point = math::sub(*point, [size / 2.0, size / 2.0]);
 
             // Rotate
             let rotation_matrix = math::rotate_radians(self.angle);

--- a/src/state.rs
+++ b/src/state.rs
@@ -77,7 +77,7 @@ impl Unit {
     }
 
     pub fn update(&mut self, dt_ms: f64) {
-        self.position = self.speed_vector * dt_ms;
+        self.position += self.speed_vector * dt_ms;
     }
 
     pub fn shoot(&self, size: f64, speed: f64) -> Bullet {
@@ -108,7 +108,7 @@ impl Bullet {
     }
 
     pub fn update(&mut self, dt_ms: f64) {
-        self.position = self.speed_vector * dt_ms;
+        self.position += self.speed_vector * dt_ms;
     }
 }
 
@@ -233,5 +233,63 @@ impl WorldState {
             x: x,
             y: y,
         }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unit_update_stationary() {
+        //! The position of a unit should not change on update when no speed
+        //! vector is defined.
+        let pos = Vec2::new(20.0, 10.0);
+        let mut unit = Unit::new(1, pos);
+        assert_eq!(unit.position, pos);
+        unit.update(10.0);
+        assert_eq!(unit.position, pos);
+        unit.update(1000.0);
+        assert_eq!(unit.position, pos);
+    }
+
+    #[test]
+    fn test_unit_update_moving() {
+        //! The position of a unit should not change on update when no speed
+        //! vector is defined.
+        let mut unit = Unit::new(1, Vec2::new(20.0, 10.0));
+        unit.speed_vector = Vec2::new(1.0, 2.0);
+        assert_eq!(unit.position, Vec2::new(20.0, 10.0));
+        unit.update(1.0);
+        assert_eq!(unit.position, Vec2::new(21.0, 12.0));
+        unit.update(100.0);
+        assert_eq!(unit.position, Vec2::new(121.0, 212.0));
+    }
+
+    #[test]
+    fn test_bullet_update_stationary() {
+        //! The position of a bullet should not change on update when a zero
+        //! speed vector is defined.
+        let pos = Vec2::new(20.0, 10.0);
+        let speed = Vec2::new(0.0, 0.0);
+        let mut bullet = Bullet::new(pos, speed);
+        assert_eq!(bullet.position, pos);
+        bullet.update(10.0);
+        assert_eq!(bullet.position, pos);
+        bullet.update(1000.0);
+        assert_eq!(bullet.position, pos);
+    }
+
+    #[test]
+    fn test_bullet_update_moving() {
+        //! The position of a bullet should not change on update when no speed
+        //! vector is defined.
+        let mut bullet = Bullet::new(Vec2::new(20.0, 10.0), Vec2::new(1.0, 2.0));
+        assert_eq!(bullet.position, Vec2::new(20.0, 10.0));
+        bullet.update(1.0);
+        assert_eq!(bullet.position, Vec2::new(21.0, 12.0));
+        bullet.update(100.0);
+        assert_eq!(bullet.position, Vec2::new(121.0, 212.0));
     }
 }


### PR DESCRIPTION
I first tried to integrate [nalgebra](https://github.com/sebcrozet/nalgebra), but it's definitely not the right library for us, it's more focussed on N-dimensionality and too generic.

cgmath on the other hand is optimized for computer graphics and provides very convenient functionality like a `From<[f64; f64]>` impl for the `Vector2` type or `.x` and `.y` accessors on `Vector2`.

It probably has all features we need from a linalg lib, like operator overloading and functions like [magnitude2](https://docs.rs/cgmath/0.15.0/cgmath/prelude/trait.InnerSpace.html#method.magnitude2).

This PR is WIP since it needs to port some vector operations currently used from piston to cgmath itself. Also, it's based on the `implement_bullets` branch, so #58 needs to be merged first.